### PR TITLE
Add support for validating against test credit card numbers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,24 @@ var _defaults = {
     expiryMonth: 'expiryMonth',
     expiryYear: 'expiryYear',
     cvv: 'cvv'
-  }
+  },
+  //From https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
+  testCards: [
+    378282246310005, //amex
+    371449635398431, //amex
+    378734493671000, //amex corp
+    30569309025904, //diners club
+    38520000023237, //diners club
+    6011111111111117, //discover
+    6011000990139424, //discover
+    3530111333300000, //jcb
+    3566002020360505, //jcb
+    5555555555554444, //mastercard
+    5105105105105100, //mastercard
+    4111111111111111, //visa
+    4012888888881881, //visa
+    4222222222222 //visa
+  ]
 };
 
 // Setup Aliases
@@ -119,11 +136,13 @@ function determineCardType(number, options) {
   return null;
 }
 
-
-function isValidCardNumber(number, type, options) {
-  return doesNumberMatchType(number, type, options) && luhn(number);
+function isValidTestCardNumber(number) {
+  return _defaults.testCards.indexOf(number) !== -1;
 }
 
+function isValidCardNumber(number, type, options) {
+   return isValidTestCardNumber(number) || (doesNumberMatchType(number, type, options) && luhn(number));
+}
 
 function isValidExpiryMonth(month, options) {
   var settings = Hoek.applyToDefaults(_defaults.expiryMonths, options || {});
@@ -252,6 +271,7 @@ module.exports = {
   validate: validate,
   determineCardType: determineCardType,
   isValidCardNumber: isValidCardNumber,
+  isValidTestCardNumber: isValidTestCardNumber,
   isValidExpiryMonth: isValidExpiryMonth,
   isValidExpiryYear: isValidExpiryYear,
   doesNumberMatchType: doesNumberMatchType,

--- a/test/index.js
+++ b/test/index.js
@@ -267,6 +267,16 @@ describe('CreditCard', function() {
       done();
     });
 
+    it('returns true for valid test cards', function(done) {
+      var defaults = CreditCard.defaults();
+
+      defaults.testCards.forEach(function(number) {
+          expect(CreditCard.isValidCardNumber(number, '')).to.equal(true);
+      });
+
+      done();
+    });
+
     it('returns false for numbers that pass luhn but fail are invalid', function(done) {
       expect(CreditCard.isValidCardNumber('123', 'AMERICANEXPRESS')).to.equal(false);
       done();


### PR DESCRIPTION
There are test cards that I would like to validate that do not work against the standard validator (eg `5105105105105100`, from https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm).

This PR does the following:
1. Adds an array of test cards to the default.
2. Checks if a test card is fed through the validator.
3. Adds unit tests to test that test cards are considered valid.
