### PR TITLE
Allow the module to be used without --harmony flag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const Reach = require('reach');
 
-let _defaults = {
+var _defaults = {
   cardTypes: {
     VISA: {
       cardType: 'VISA',
@@ -79,7 +79,7 @@ function validate (card, options) {
   const expiryYear = Reach(card, schema.expiryYear);
   const cvv = sanitizeNumberString(Reach(card, schema.cvv));
   const customValidationFn = settings.customValidation;
-  let customValidation;
+  var customValidation;
 
   // Optional custom validation
   if (typeof customValidationFn === 'function') {
@@ -104,7 +104,7 @@ function determineCardType (number, options) {
 
   number = sanitizeNumberString(number);
 
-  for (let i = 0; i < keys.length; ++i) {
+  for (var i = 0; i < keys.length; ++i) {
     const key = keys[i];
     const type = cardTypes[key];
 
@@ -183,11 +183,11 @@ function luhn (number) {
     return false;
   }
 
-  let nCheck = 0;
-  let bEven = false;
-  let nDigit;
+  var nCheck = 0;
+  var bEven = false;
+  var nDigit;
 
-  for (let i = number.length - 1; i >= 0; --i) {
+  for (var i = number.length - 1; i >= 0; --i) {
     nDigit = ~~number.charAt(i);
 
     if (bEven) {
@@ -229,7 +229,7 @@ function reset () {
 }
 
 function _setupCardTypeAliases (type, aliases) {
-  for (let i = 0; i < aliases.length; ++i) {
+  for (var i = 0; i < aliases.length; ++i) {
     _defaults.cardTypes[aliases[i]] = _defaults.cardTypes[type];
   }
 }


### PR DESCRIPTION
`let` keyword is not available yet in node 4.0.0, so this module is unusable
in that environment without --harmony flag.
